### PR TITLE
add collection info to api response

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,11 +40,18 @@ type Pagination struct {
 	Page    int `json:"page"`
 }
 
+type CollectionInfo struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Alias string `json:"alias"`
+}
+
 type ContentItem struct {
-	ID        uint                   `json:"id"`
-	CreatedAt string                 `json:"created_at"`
-	UpdatedAt string                 `json:"updated_at"`
-	Values    map[string]interface{} `json:"values"`
+	ID         uint                   `json:"id"`
+	CreatedAt  string                 `json:"created_at"`
+	UpdatedAt  string                 `json:"updated_at"`
+	Values     map[string]interface{} `json:"values"`
+	Collection *CollectionInfo        `json:"collection,omitempty"`
 }
 
 func (c *ApiClient) get(path string, target any) error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content items now include optional collection metadata (ID, name, alias) when available from the service. This enables richer displays and filtering/grouping by collection without extra calls. Backward compatible: existing consumers remain unaffected if collection data is absent. No changes to request/response flows or error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->